### PR TITLE
New Cargo Crates for DS13

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -363,15 +363,6 @@
 					/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
 
-/datum/supply_pack/security/taser
-	name = "Taser Crate"
-	desc = "From the depths of stunbased combat, this order rises above, supreme. Contains three hybrid tasers, capable of firing both electrodes and disabling shots. Requires Security access to open."
-	cost = 3000
-	contains = list(/obj/item/gun/energy/e_gun/advtaser,
-					/obj/item/gun/energy/e_gun/advtaser,
-					/obj/item/gun/energy/e_gun/advtaser)
-	crate_name = "taser crate"
-
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
@@ -526,6 +517,18 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
+/datum/supply_pack/security/armory/ERTComm
+	name = "ERT Commander Crate"
+	desc = "!@#$%@#TRANSMISSION START: I have no idea how legal this is, but I'll sell you guys my old outfit, I'm sure CentCom won't care enough to intercept it TRANSMISSION END!!@%$^#"
+	cost = 1000000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/ert,
+					/obj/item/storage/backpack/ert,
+					/obj/item/clothing/shoes/combat/swat,
+					/obj/item/clothing/glasses/hud/security/sunglasses,
+					/obj/item/storage/belt/military/assault,
+					/obj/item/switchblade,
+					/obj/item/clothing/gloves/combat)
+	crate_name = "ERTCommCrate"
 
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Auto Rifle Crate"
@@ -562,6 +565,14 @@
 					/obj/machinery/shieldgen)
 	crate_name = "anti-breach shield projector crate"
 
+/datum/supply_pack/engineering/ShowerCrate
+	name = "DIFY Shower Kit"
+	desc = "With the all new, Did it for you(TM) Shower kit, you get one completely assembled shower to be deployed anywhere on station, with a rubber ducky for free! (ONLY OPEN IN FINAL DESIRED LOCATION, NT IS NOT RESPONSIBLE FOR ACCIDENTAL OR EARLY OPENED CRATES)"
+	cost = 2500
+	contains = list(/obj/machinery/shower,
+					/obj/item/bikehorn/rubberducky)
+	crate_name = "ShowerCrate"
+	
 /datum/supply_pack/engineering/conveyor
 	name = "Conveyor Assembly Crate"
 	desc = "Keep production moving along with six conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
@@ -1626,6 +1637,22 @@
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/organic/strangeseeds
+	name = "Strange Seeds Crate"
+	desc = "Are you tired of trying to sort through seeds? With the all new Strange Seeds Crate(TM) You get all of what you want with none of what you don't!"
+	cost = 10000
+	contains = list(/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random)
+	crate_name = "strange seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 //////////////////////////////////////////////////////////////////////////////
 ////////////////////////////// Livestock /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds new cargo crates for DS13. most focusing on convienience or content otherwise unavailable to players

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds three new crates, mostly as tests for future crate types
Strange Seeds Crate: Just 10 strange seeds packets, cost upped to 10,000 from the cost of the exotic seeds crate
ERT Commander Crate: A crate full of ERT gear, for the commander, cost set at 1,000,000, 
Shower Crate: Literally just a shower, will be placed wherever the crate is opened

## Why It's Good For The Game
These crates are all either some kind of bandaid, such as the inability to craft showers, a convienience tweak, since the seeds crate allows you to bypass sorting out exotic crates for strange seeds, and the ERT commander crate, which, is meant to be something of actual value to strive for in cargo, rather than the bicycle which is of little real use

## Changelog
:cl:
add: Strange Seeds Crate
add: ERT Commander Crate
add: Shower Crate
/:cl:
